### PR TITLE
fix 课程位置签到 "validate"

### DIFF
--- a/apps/server/src/configs/api.ts
+++ b/apps/server/src/configs/api.ts
@@ -10,6 +10,14 @@ export const PRESIGN = {
   URL: 'https://mobilelearn.chaoxing.com/newsign/preSign',
   METHOD: 'GET'
 };
+export const ANALYSIS = {
+  URL: 'https://mobilelearn.chaoxing.com/pptSign/analysis',
+  METHOD: 'GET'
+};
+export const ANALYSIS2 = {
+  URL: 'https://mobilelearn.chaoxing.com/pptSign/analysis2',
+  METHOD: 'GET'
+};
 export const PPTSIGN = {
   URL: 'https://mobilelearn.chaoxing.com/pptSign/stuSignajax',
   METHOD: 'GET'

--- a/apps/server/src/functions/activity.ts
+++ b/apps/server/src/functions/activity.ts
@@ -139,6 +139,13 @@ export const preSign = async (args: BasicCookie & { activeId: string; courseId: 
     }
   );
   console.log(`analysis 请求结果：${analysis2Result.data}`);
+
+  // sleep for 500ms.
+  await new Promise<void>(resolve =>
+    setTimeout(async () => {
+      resolve();
+    }, 500),
+  );
 };
 
 export const preSign2 = async (args: BasicCookie & { activeId: string; chatId: string; _uid: string; tuid: string; }) => {

--- a/apps/server/src/functions/activity.ts
+++ b/apps/server/src/functions/activity.ts
@@ -1,4 +1,4 @@
-import { ACTIVELIST, CHAT_GROUP, PPTACTIVEINFO, PRESIGN } from '../configs/api';
+import { ACTIVELIST, ANALYSIS, ANALYSIS2, CHAT_GROUP, PPTACTIVEINFO, PRESIGN } from '../configs/api';
 import { cookieSerialize, request } from '../utils/request';
 
 /**
@@ -111,6 +111,34 @@ export const preSign = async (args: BasicCookie & { activeId: string; courseId: 
     }
   );
   console.log('[预签]已请求');
+
+  // analysis
+  const analysisResult = await request(
+    `${ANALYSIS.URL}?vs=1&DB_STRATEGY=RANDOM&aid=${activeId}`,
+    {
+      secure: true,
+      headers: {
+        Cookie: cookieSerialize(cookies),
+      },
+    }
+  );
+  let code: string = analysisResult.data;
+  const code_start = code.indexOf('code=\'+\'') + 8;
+  code = code.substring(code_start, code.length);
+  const code_end = code.indexOf('\'');
+  code = code.substring(0, code_end);
+
+  // analysis2
+  const analysis2Result = await request(
+    `${ANALYSIS2.URL}?DB_STRATEGY=RANDOM&code=${code}`,
+    {
+      secure: true,
+      headers: {
+        Cookie: cookieSerialize(cookies),
+      },
+    }
+  );
+  console.log(`analysis 请求结果：${analysis2Result.data}`);
 };
 
 export const preSign2 = async (args: BasicCookie & { activeId: string; chatId: string; _uid: string; tuid: string; }) => {


### PR DESCRIPTION
fix #196 #197 

这两个issues是重复的。

根据[这里](https://github.com/cxOrz/chaoxing-sign-cli/issues/197#issuecomment-1835283705)的第三条，添加了 analysis 和 analysis2 的请求。这两个请求我放到了预签到函数`preSign`里。

根据第四条添加了500ms延迟。

第一、二条似乎无关。故没有实现。

群聊签到未做处理。