### PR TITLE
fix 姓名显示为"IC " 简化请求协议判断

### DIFF
--- a/apps/server/src/configs/api.ts
+++ b/apps/server/src/configs/api.ts
@@ -1,9 +1,9 @@
 export const LOGIN_PAGE = {
-  URL: 'http://passport2.chaoxing.com/mlogin?fid=&newversion=true&refer=http%3A%2F%2Fi.chaoxing.com',
+  URL: 'https://passport2.chaoxing.com/mlogin?fid=&newversion=true&refer=http%3A%2F%2Fi.chaoxing.com',
   METHOD: 'GET'
 };
 export const LOGIN = {
-  URL: 'http://passport2.chaoxing.com/fanyalogin',
+  URL: 'https://passport2.chaoxing.com/fanyalogin',
   METHOD: 'POST',
 };
 export const PRESIGN = {
@@ -27,11 +27,11 @@ export const PPTACTIVEINFO = {
   METHOD: 'GET'
 };
 export const COURSELIST = {
-  URL: 'http://mooc1-1.chaoxing.com/visit/courselistdata',
+  URL: 'https://mooc1-1.chaoxing.com/visit/courselistdata',
   METHOD: 'POST'
 };
 export const BACKCLAZZDATA = {
-  URL: 'http://mooc1-api.chaoxing.com/mycourse/backclazzdata',
+  URL: 'https://mooc1-api.chaoxing.com/mycourse/backclazzdata',
   METHOD: 'GET'
 };
 export const ACTIVELIST = {
@@ -39,7 +39,7 @@ export const ACTIVELIST = {
   METHOD: 'GET'
 };
 export const ACCOUNTMANAGE = {
-  URL: 'http://passport2.chaoxing.com/mooc/accountManage',
+  URL: 'https://passport2.chaoxing.com/mooc/accountManage',
   METHOD: 'GET'
 };
 export const PANCHAOXING = {

--- a/apps/server/src/functions/activity.ts
+++ b/apps/server/src/functions/activity.ts
@@ -49,7 +49,6 @@ export const getActivity = async (args: BasicCookie & { course: CourseType; }): 
   const result = await request(
     `${ACTIVELIST.URL}?fid=0&courseId=${course.courseId}&classId=${course.classId}&_=${new Date().getTime()}`,
     {
-      secure: true,
       headers: {
         Cookie: cookieSerialize(cookies),
       },
@@ -89,7 +88,6 @@ export const getActivity = async (args: BasicCookie & { course: CourseType; }): 
  */
 export const getPPTActiveInfo = async ({ activeId, ...cookies }: BasicCookie & { activeId: string; }) => {
   const result = await request(`${PPTACTIVEINFO.URL}?activeId=${activeId}`, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },
@@ -104,7 +102,6 @@ export const preSign = async (args: BasicCookie & { activeId: string; courseId: 
   await request(
     `${PRESIGN.URL}?courseId=${courseId}&classId=${classId}&activePrimaryId=${activeId}&general=1&sys=1&ls=1&appType=15&&tid=&uid=${args._uid}&ut=s`,
     {
-      secure: true,
       headers: {
         Cookie: cookieSerialize(cookies),
       },
@@ -116,7 +113,6 @@ export const preSign = async (args: BasicCookie & { activeId: string; courseId: 
   const analysisResult = await request(
     `${ANALYSIS.URL}?vs=1&DB_STRATEGY=RANDOM&aid=${activeId}`,
     {
-      secure: true,
       headers: {
         Cookie: cookieSerialize(cookies),
       },
@@ -132,7 +128,6 @@ export const preSign = async (args: BasicCookie & { activeId: string; courseId: 
   const analysis2Result = await request(
     `${ANALYSIS2.URL}?DB_STRATEGY=RANDOM&code=${code}`,
     {
-      secure: true,
       headers: {
         Cookie: cookieSerialize(cookies),
       },
@@ -153,7 +148,6 @@ export const preSign2 = async (args: BasicCookie & { activeId: string; chatId: s
   const result = await request(
     `${CHAT_GROUP.PRESTUSIGN.URL}?activeId=${activeId}&code=&uid=${cookies._uid}&courseId=null&classId=0&general=0&chatId=${chatId}&appType=0&tid=${tuid}&atype=null&sys=0`,
     {
-      secure: true,
       headers: {
         Cookie: cookieSerialize(cookies),
       },

--- a/apps/server/src/functions/general.ts
+++ b/apps/server/src/functions/general.ts
@@ -5,7 +5,6 @@ export const GeneralSign = async (args: BasicCookie & { name: string; activeId: 
   const { name, activeId, fid, ...cookies } = args;
   const url = `${PPTSIGN.URL}?activeId=${activeId}&uid=${cookies._uid}&clientip=&latitude=-1&longitude=-1&appType=15&fid=${fid}&name=${name}`;
   const result = await request(url, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },
@@ -22,7 +21,6 @@ export const GeneralSign_2 = async (args: BasicCookie & { activeId: string; }): 
   const { activeId, ...cookies } = args;
   const url = `${CHAT_GROUP.SIGN.URL}?activeId=${activeId}&uid=${cookies._uid}&clientip=`;
   const result = await request(url, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },

--- a/apps/server/src/functions/location.ts
+++ b/apps/server/src/functions/location.ts
@@ -23,7 +23,6 @@ export const LocationSign: LocationSignType = async (args): Promise<string> => {
     const { name, address, activeId, lat, lon, fid, ...cookies } = args;
     const url = `${PPTSIGN.URL}?name=${name}&address=${address}&activeId=${activeId}&uid=${cookies._uid}&clientip=&latitude=${lat}&longitude=${lon}&fid=${fid}&appType=15&ifTiJiao=1`;
     const result = await request(url, {
-      secure: true,
       headers: {
         Cookie: cookieSerialize(cookies),
       },
@@ -35,7 +34,6 @@ export const LocationSign: LocationSignType = async (args): Promise<string> => {
     for (let i = 0; i < presetAddress.length; i++) {
       const url = `${PPTSIGN.URL}?name=${name}&address=${presetAddress[i].address}&activeId=${activeId}&uid=${cookies._uid}&clientip=&latitude=${presetAddress[i].lat}&longitude=${presetAddress[i].lon}&fid=${fid}&appType=15&ifTiJiao=1`;
       const result = await request(url, {
-        secure: true,
         headers: {
           Cookie: cookieSerialize(cookies),
         },
@@ -65,7 +63,6 @@ export const LocationSign_2: LocationSignType = async (args): Promise<string> =>
     const result = await request(
       CHAT_GROUP.SIGN.URL,
       {
-        secure: true,
         method: 'POST',
         headers: {
           'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
@@ -83,7 +80,6 @@ export const LocationSign_2: LocationSignType = async (args): Promise<string> =>
       const result = await request(
         CHAT_GROUP.SIGN.URL,
         {
-          secure: true,
           method: 'POST',
           headers: {
             'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',

--- a/apps/server/src/functions/photo.ts
+++ b/apps/server/src/functions/photo.ts
@@ -13,7 +13,6 @@ export const PhotoSign = async (
     cookies._uid
   }&clientip=&useragent=&latitude=-1&longitude=-1&appType=15&fid=${fid}&objectId=${objectId}&name=${encodeURIComponent(name)}`;
   const result = await request(url, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },
@@ -27,7 +26,6 @@ export const PhotoSign_2 = async (args: BasicCookie & { objectId: string; active
   const { activeId, objectId, ...cookies } = args;
   const url = `${CHAT_GROUP.SIGN.URL}?activeId=${activeId}&uid=${cookies._uid}&clientip=&useragent=&latitude=-1&longitude=-1&fid=0&objectId=${objectId}`;
   const result = await request(url, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },
@@ -41,7 +39,6 @@ export const PhotoSign_2 = async (args: BasicCookie & { objectId: string; active
 export const getObjectIdFromcxPan = async (cookies: BasicCookie) => {
   // 获得 parentId, enc
   const result = await request(PANCHAOXING.URL, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },
@@ -56,7 +53,6 @@ export const getObjectIdFromcxPan = async (cookies: BasicCookie) => {
   const result_panlist = await request(
     `${PANLIST.URL}?puid=0&shareid=0&parentId=${parentId}&page=1&size=50&enc=${enc}`,
     {
-      secure: true,
       method: PANLIST.METHOD,
       headers: {
         Cookie: cookieSerialize(cookies),
@@ -91,7 +87,6 @@ export const uploadPhoto = async (args: BasicCookie & { buffer: Buffer; token: s
   const result = await request(
     `${PANUPLOAD.URL}?_from=mobilelearn&_token=${token}`,
     {
-      secure: true,
       method: PANUPLOAD.METHOD,
       headers: {
         Cookie: cookieSerialize(cookies),

--- a/apps/server/src/functions/qrcode.ts
+++ b/apps/server/src/functions/qrcode.ts
@@ -5,7 +5,6 @@ export const QRCodeSign = async (args: BasicCookie & { enc: string; name: string
   const { enc, name, fid, activeId, lat, lon, address, altitude, ...cookies } = args;
   const urlParams = `${PPTSIGN.URL}?enc=${enc}&name=${name}&activeId=${activeId}&uid=${cookies._uid}&clientip=&location={"result":"1","address":"${address}","latitude":${lat},"longitude":${lon},"altitude":${altitude}}&latitude=-1&longitude=-1&fid=${fid}&appType=15`;
   const result = await request(encodeURI(urlParams), {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },

--- a/apps/server/src/functions/user.ts
+++ b/apps/server/src/functions/user.ts
@@ -133,7 +133,6 @@ export const getAccountInfo = async (cookies: BasicCookie): Promise<string> => {
 // 获取用户鉴权token
 export const getPanToken = async (cookies: BasicCookie) => {
   const result = await request(PANTOKEN.URL, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },
@@ -169,7 +168,6 @@ export const getIMParams = async (cookies: BasicCookie): Promise<IMParamsType | 
     myPuid: '',
   };
   const result = await request(WEBIM.URL, {
-    secure: true,
     headers: {
       Cookie: cookieSerialize(cookies),
     },

--- a/apps/server/src/utils/request.ts
+++ b/apps/server/src/utils/request.ts
@@ -12,7 +12,6 @@ enum RequestMethod {
 type RequestMethodType = RequestMethod | string;
 
 interface RequestOptions {
-  secure?: boolean;
   headers?: ClientRequestArgs['headers'];
   method?: RequestMethodType;
   gzip?: boolean;
@@ -26,7 +25,7 @@ interface ResponseType {
 
 /**
  * @param url 接口地址
- * @param options headers, method, secure 参数配置
+ * @param options headers, method 参数配置
  * @param payload 当进行POST请求时传入数据
  * @returns
  */
@@ -34,7 +33,7 @@ const request = (url: string, options: RequestOptions, payload?: any): Promise<R
   // 设置默认值
   options.method = options.method || 'GET';
 
-  const protocol = options.secure ? https : http;
+  const protocol = url.startsWith('https') ? https : http;
 
   const result = new Promise<ResponseType>((resolve, reject) => {
     let data = '';


### PR DESCRIPTION
## 修复登录以及签到时姓名显示为`IC `的 BUG

该 BUG 由于`user.ts`中函数`getAccountInfo()`请求构造错误，导致解析响应体异常

故障原因：

该函数为了通过 Cookie 获取用户姓名，请求用户设置页面的 url `http://passport2.chaoxing.com/mooc/accountManage`，通过服务端 SSR 为 html 后提取姓名字符串
测试得知，这个 url 不再接受 http 协议，所以通过301重定向至`https://passport2.chaoxing.com/mooc/accountManage`，但并未实现重定向跟随，而是通过`result.data`获取了301页面的响应体：

```html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>tengine</center>
</body>
</html>
```

函数`String.indexOf('messageName')`无法找到`messageName`，返回值为`-1`，所以`end_of_messageName`最终为`19`，导致`name`变量被赋值为`<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">`中的`IC `

详见 https://github.com/cxOrz/chaoxing-sign-cli/blob/main/apps/server/src/functions/user.ts#L120-L131

## 简化请求协议判断

后端程序中用于 API 构造和发送请求的函数`request.ts`中的`request()`的形参`options`具有`secure`这个属性，用来指定使用 http/https 协议发送请求，然而这样设计不利于后期维护和扩展，应该判断 url 是否以`https`起始更合适

另外，由于学习通各个 url 接口均不再接受 http 协议，修改`api.ts`中所有 http 的 url 规避后续的异常